### PR TITLE
ProfilePage now imports id from PAGE_IDS

### DIFF
--- a/app/imports/ui/components/NavBar.jsx
+++ b/app/imports/ui/components/NavBar.jsx
@@ -96,7 +96,8 @@ const NavBar = () => {
                               activeClassName="active"
                               to={ROUTES.SUGGEST_TOOL_SKILL}
                               key='suggest-tool-skill'>Suggest Tool/Skill</Nav.Link>,
-                    <Nav.Link as={NavLink}
+                    <Nav.Link id={COMPONENT_IDS.TEAM_INVITATIONS_BUTTON}
+                              as={NavLink}
                               activeClassName="active"
                               to={ROUTES.TEAM_INVITATIONS} key='team-invitations'>Invitations</Nav.Link>,
                   ]

--- a/app/imports/ui/testIDs/componentIDs.js
+++ b/app/imports/ui/testIDs/componentIDs.js
@@ -50,4 +50,5 @@ export const COMPONENT_IDS = {
   CREATE_PROFILE_CHALLENGES: 'create-profile-challenges',
   CREATE_PROFILE_SUBMIT: 'create-profile-submit',
   LIST_PARTICIPANTS: 'list-participants',
+  TEAM_INVITATIONS_BUTTON: 'team-invitations-button',
 };

--- a/app/tests/navbar.component.js
+++ b/app/tests/navbar.component.js
@@ -71,6 +71,11 @@ class NavBar {
     await testController.expect(Selector(`#${COMPONENT_IDS.LIST_PARTICIPANTS}`).exists).ok();
     await testController.click(`#${COMPONENT_IDS.LIST_PARTICIPANTS}`);
   }
+
+  async gotoTeamInvitations(testController) {
+    await testController.expect(Selector(`#${COMPONENT_IDS.TEAM_INVITATIONS_BUTTON}`).exists).ok();
+    await testController.click(`#${COMPONENT_IDS.TEAM_INVITATIONS_BUTTON}`);
+  }
 }
 
 export const navBar = new NavBar();

--- a/app/tests/teamInvitationsPage.js
+++ b/app/tests/teamInvitationsPage.js
@@ -1,0 +1,15 @@
+import { Selector } from 'testcafe';
+import { PAGE_IDS } from '../imports/ui/testIDs/pageIDs';
+
+class TeamInvitationsPage {
+  constructor() {
+    this.pageId = `#${PAGE_IDS.TEAM_INVITATIONS_PAGE}`;
+    this.pageSelector = Selector(this.pageId);
+  }
+
+  async isDisplayed(testController) {
+    await testController.wait(10000).expect(this.pageSelector.exists).ok();
+  }
+}
+
+export const teamInvitationsPage = new TeamInvitationsPage();

--- a/app/tests/tests.testcafe.js
+++ b/app/tests/tests.testcafe.js
@@ -16,6 +16,7 @@ import { viewTeamsPage } from './viewTeamsPage.page';
 import { suggestToolSkillPage } from './suggestToolSkillPage.page';
 import { profilePage } from './profilePage';
 import { listParticipantsPage } from './listParticipants.page';
+import { teamInvitationsPage } from './teamInvitationsPage';
 /* global fixture:false, test:false */
 
 const credentialsA = { username: 'admin@hacchui.ics.foo.com', password: 'changeme' };
@@ -169,4 +170,11 @@ test('Test that ViewTeams pages function', async (testController) => {
   await navBar.gotoConfigueHACC(testController);
   await manageHaccWidgetComponents.gotoViewTeamsPage(testController);
   await viewTeamsPage.clickFilter(testController);
+});
+
+test('Test that TeamInvitations page renders', async (testController) => {
+  await navBar.gotoSigninPage(testController);
+  await signinPage.signin(testController, credentialsB.username, credentialsB.password);
+  await navBar.gotoTeamInvitations(testController);
+  await teamInvitationsPage.isDisplayed(testController);
 });


### PR DESCRIPTION
![image](https://github.com/bang-software/HACC-Hui-414f23/assets/97987234/3b095ec9-fd69-46e8-b132-d1aa793d34da)

- Styled the navbar
- Edited acceptance tests to be repeatable (commented out functionality testing of CreateProfile page)
- Fixed bug in EditChallengeWidget (now imports withRouter from 'react-router-dom' instead of 'react-router')
- Also had to re-install uniforms ¯\_(ツ)_/¯
- close #150 